### PR TITLE
get rid of create account grpc flow in the service layer

### DIFF
--- a/src/main/java/org/interledger/spsp/server/config/ilp/IlpOverHttpConfig.java
+++ b/src/main/java/org/interledger/spsp/server/config/ilp/IlpOverHttpConfig.java
@@ -167,10 +167,9 @@ public class IlpOverHttpConfig {
     ConnectorAdminClient adminClient,
     ConnectorRoutesClient connectorRoutesClient,
     @Qualifier(SPSP) OutgoingLinkSettings spspLinkSettings,
-    @Qualifier(SPSP) InterledgerAddressPrefix spspAddressPrefix,
-    AccountGeneratorService accountGeneratorService
+    @Qualifier(SPSP) InterledgerAddressPrefix spspAddressPrefix
   ) {
-    return new NewAccountService(adminClient, connectorRoutesClient, spspLinkSettings, spspAddressPrefix, accountGeneratorService);
+    return new NewAccountService(adminClient, connectorRoutesClient, spspLinkSettings, spspAddressPrefix);
   }
 
   @Bean

--- a/src/main/java/org/interledger/spsp/server/grpc/AccountGrpcHandler.java
+++ b/src/main/java/org/interledger/spsp/server/grpc/AccountGrpcHandler.java
@@ -7,6 +7,8 @@ import org.interledger.connector.client.ConnectorAdminClient;
 import org.interledger.spsp.server.client.ConnectorRoutesClient;
 import org.interledger.spsp.server.grpc.auth.IlpGrpcAuthContext;
 import org.interledger.spsp.server.grpc.services.AccountRequestResponseConverter;
+import org.interledger.spsp.server.model.CreateAccountRestRequest;
+import org.interledger.spsp.server.model.ImmutableCreateAccountRestRequest;
 import org.interledger.spsp.server.services.NewAccountService;
 import org.interledger.spsp.server.util.OptionalAuthToken;
 
@@ -19,6 +21,8 @@ import org.lognet.springboot.grpc.GRpcService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
 
 @GRpcService
 public class AccountGrpcHandler extends AccountServiceGrpc.AccountServiceImplBase {
@@ -69,8 +73,9 @@ public class AccountGrpcHandler extends AccountServiceGrpc.AccountServiceImplBas
     Status grpcStatus;
     try {
       // Create account on the connector
+      Optional<CreateAccountRestRequest> convertedRequest = createAccountRestRequestFromGrpc(request);
       AccountSettings returnedAccountSettings = newAccountService
-        .createAccount(OptionalAuthToken.of(ilpGrpcAuthContext.getAuthorizationHeader()), request);
+        .createAccount(OptionalAuthToken.of(ilpGrpcAuthContext.getAuthorizationHeader()), convertedRequest);
 
       // Convert returned AccountSettings into Grpc response object
       final CreateAccountResponse.Builder replyBuilder =
@@ -96,6 +101,62 @@ public class AccountGrpcHandler extends AccountServiceGrpc.AccountServiceImplBas
     responseObserver.onError(new StatusRuntimeException(grpcStatus));
   }
 
+  /**
+   * Convert a {@link CreateAccountRequest} into a {@link CreateAccountRestRequest} so that our service level code
+   * only has one execution path.
+   *
+   * This method will also validate that the required parameters (assetCode and assetScale) are set if any other fields are set.
+   *
+   * If no other fields are set, we can assume that the requester wanted Hermes to generate a default account for them (similar to not
+   * passing a body in the REST request equivalent). GRPC generated objects are never null, but rather use default values for fields that are
+   * left blank.
+   *
+   * If there is at least one field set in the GRPC object, we must validate the assetCode and assetScale are specified.
+   *
+   * @param request
+   * @return An {@link Optional<CreateAccountRestRequest>}. If the grpc request was empty/defaulted, return {@link Optional#empty()}
+   *        otherwise try to convert the given request to a rest request.
+   */
+  private Optional<CreateAccountRestRequest> createAccountRestRequestFromGrpc(CreateAccountRequest request) {
+    String assetCode = request.getAssetCode().isEmpty() ? null : request.getAssetCode();
+    Integer assetScale = request.getAssetScale() == 0 ? null : request.getAssetScale();
 
+    if (!requestIsEmpty(request)) {
+      ImmutableCreateAccountRestRequest.Builder requestBuilder = CreateAccountRestRequest.builder(assetCode, assetScale);
+      if (!request.getAccountId().isEmpty()) {
+        requestBuilder.accountId(request.getAccountId());
+      }
 
+      if (!request.getDescription().isEmpty()) {
+        requestBuilder.description(request.getDescription());
+      }
+
+      return Optional.of(requestBuilder.build());
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * If all the fields in the GRPC CreateAccountRequest are empty or the protobuf defaults,
+   * we can assume the requester wants Hermes to generate an account for them.
+   * @param request
+   * @return
+   */
+  private boolean requestIsEmpty(CreateAccountRequest request) {
+    if (!request.getAccountId().isEmpty()) {
+      return false;
+    }
+    if (!request.getAssetCode().isEmpty()) {
+      return false;
+    }
+    if (request.getAssetScale() != 0) {
+      return false;
+    }
+    if (!request.getDescription().isEmpty()) {
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/src/main/java/org/interledger/spsp/server/grpc/services/AccountRequestResponseConverter.java
+++ b/src/main/java/org/interledger/spsp/server/grpc/services/AccountRequestResponseConverter.java
@@ -163,27 +163,6 @@ public class AccountRequestResponseConverter {
       .putAllCustomSettings(settingsMapToGrpcSettingsMap(accountSettings.customSettings()));
   }
 
-  private static Map<String, String> settingsMapToGrpcSettingsMap(Map<String, Object> settingsMap) {
-    return settingsMap.entrySet()
-      .stream()
-      .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
-  }
-
-  public static AccountSettings accountSettingsFromCreateAccountRequest(String authToken,
-                                                                        CreateAccountRequest createAccountRequest,
-                                                                        OutgoingLinkSettings outgoingLinkSettings) {
-
-    return AccountSettings.builder()
-      .accountId(AccountId.of(createAccountRequest.getAccountId()))
-      .assetCode(createAccountRequest.getAssetCode())
-      .assetScale(createAccountRequest.getAssetScale())
-      .description(createAccountRequest.getDescription())
-      .accountRelationship(AccountRelationship.CHILD)
-      .linkType(IlpOverHttpLink.LINK_TYPE)
-      .customSettings(customSettingsFromAuthToken(authToken, outgoingLinkSettings))
-      .build();
-  }
-
   public static AccountSettings accountSettingsFromCreateAccountRequest(String authToken,
                                                                         CreateAccountRestRequest createAccountRequest,
                                                                         OutgoingLinkSettings outgoingLinkSettings) {
@@ -197,6 +176,12 @@ public class AccountRequestResponseConverter {
       .linkType(IlpOverHttpLink.LINK_TYPE)
       .customSettings(customSettingsFromAuthToken(authToken, outgoingLinkSettings))
       .build();
+  }
+
+  private static Map<String, String> settingsMapToGrpcSettingsMap(Map<String, Object> settingsMap) {
+    return settingsMap.entrySet()
+      .stream()
+      .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
   }
 
   private static Map<String, Object> customSettingsFromAuthToken(String authToken,

--- a/src/main/java/org/interledger/spsp/server/model/CreateAccountRestRequest.java
+++ b/src/main/java/org/interledger/spsp/server/model/CreateAccountRestRequest.java
@@ -9,24 +9,19 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableCreateAccountRestRequest.class)
 public interface CreateAccountRestRequest {
 
-  static ImmutableCreateAccountRestRequest.Builder builder() {
-    return ImmutableCreateAccountRestRequest.builder();
+  static ImmutableCreateAccountRestRequest.Builder builder(String assetCode, Integer assetScale) {
+    return ImmutableCreateAccountRestRequest.builder().assetCode(assetCode).assetScale(assetScale);
   }
 
   @Value.Default
   default String accountId() {
     return AccountGeneratorService.generateAccountId();
-  };
+  }
 
-  @Value.Default
-  default String assetCode() {
-    return "XRP";
-  };
 
-  @Value.Default
-  default int assetScale() {
-    return 9;
-  };
+  String assetCode();
+
+  Integer assetScale();
 
   @Value.Default
   default String description() {

--- a/src/main/java/org/interledger/spsp/server/services/AccountGeneratorService.java
+++ b/src/main/java/org/interledger/spsp/server/services/AccountGeneratorService.java
@@ -21,46 +21,16 @@ public class AccountGeneratorService {
    * TODO: Use a library that generates more secure tokens
    * @return Random alphanumeric simple auth token with 13 characters
    */
-  public String generateSimpleAuthCredentials() {
+  public static String generateSimpleAuthCredentials() {
     return RandomStringUtils.randomAlphanumeric(13);
-  }
-
-  /**
-   * If the request isnt empty, just return it, otherwise create a default account with a generated accountID
-   * @param createAccountRequest a {@link Optional < CreateAccountRestRequest >} from a REST controller
-   * @return a CreateAccountRestRequest (either given or generated)
-   */
-  public CreateAccountRestRequest fillInCreateAccountRequest(Optional<CreateAccountRestRequest> createAccountRequest) {
-    return createAccountRequest.orElseGet(this::newDefaultCreateAccountRequest);
-  }
-
-  /**
-   * Returns a {@link CreateAccountRequest} with any fields filled in with default values
-   * @param createAccountRequest a {@link CreateAccountRequest} from a GRPC handler.
-   * @return a CreateAccountRestRequest (either given or filled in by this method)
-   */
-  public CreateAccountRequest fillInCreateAccountRequest(CreateAccountRequest createAccountRequest) {
-
-    // Purposely not setting auth token in proto object, as an auth token may be generated outside the proto object.
-    // This will allow us to get rid of authToken from the proto object and instead pass it as an Authorization header
-    return CreateAccountRequest.newBuilder()
-      .setAccountId(createAccountRequest.getAccountId().isEmpty() ? generateAccountId() : createAccountRequest.getAccountId())
-      .setAssetCode(createAccountRequest.getAssetCode().isEmpty() ? "XRP" : createAccountRequest.getAssetCode())
-      .setAssetScale(createAccountRequest.getAssetScale() == 0 ? 9 : createAccountRequest.getAssetScale())
-      .setDescription(createAccountRequest.getDescription())
-      .build();
   }
 
   /**
    * Generates a {@link CreateAccountRestRequest} if none is given
    * @return a {@link CreateAccountRestRequest} with a generated accountId
    */
-  public CreateAccountRestRequest newDefaultCreateAccountRequest() {
-    return CreateAccountRestRequest.builder()
-      .accountId(generateAccountId())
-      .assetCode("XRP")
-      .assetScale(9)
-      .build();
+  public static CreateAccountRestRequest newDefaultCreateAccountRequest() {
+    return CreateAccountRestRequest.builder("XRP", 9).build();
   }
 
   /**


### PR DESCRIPTION
This PR converts a GRPC `CreateAccountRequest` into a `CreateAccountRestRequest` in `AccountGrpcHandler`.  This fixes two things:

- We no longer need analogous methods in `NewAccountService` for GRPC and REST requests
- We can use the `@Value.Immutable` `CreateAccountRestRequest` to validate request input.  This validation is now as follows:  
       - If the requester passes in a GRPC request with all blank fields, or if they perform a REST request without a `body`, Hermes will generate an account for them with default `assetCode` and `assetScale`, and generated `accountId`
       - If the requester passes in a GRPC request with ANY fields populated, they must pass in `assetCode` and `assetScale`.  On the REST side, if they pass in a request body but do not specify `assetCode` and `assetScale`, validation will fail.
