### PR TITLE
add ilpOverHttpUrl to metadata endpoint

### DIFF
--- a/src/main/java/org/interledger/spsp/server/config/model/HermesSettingsResponse.java
+++ b/src/main/java/org/interledger/spsp/server/config/model/HermesSettingsResponse.java
@@ -12,4 +12,7 @@ public interface HermesSettingsResponse {
   }
 
   String version();
+
+  String ilpOverHttpUrl();
+
 }

--- a/src/main/java/org/interledger/spsp/server/controllers/RootController.java
+++ b/src/main/java/org/interledger/spsp/server/controllers/RootController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import org.interledger.spsp.server.config.model.HermesSettingsResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,9 @@ public class RootController {
   @Autowired
   private BuildProperties buildProperties;
 
+  @Value("${interledger.connector.connector-url}")
+  private String ilpOverHttpUrl;
+
   @RequestMapping(
     method = RequestMethod.GET,
     produces = {APPLICATION_JSON_VALUE, MediaTypes.PROBLEM_VALUE}
@@ -30,6 +34,7 @@ public class RootController {
     return new ResponseEntity<>(
       HermesSettingsResponse.builder()
         .version(this.buildProperties.getVersion())
+        .ilpOverHttpUrl(ilpOverHttpUrl)
         .build(),
       HttpStatus.OK
     );

--- a/src/test/java/org/interledger/spsp/server/controllers/RootControllerTest.java
+++ b/src/test/java/org/interledger/spsp/server/controllers/RootControllerTest.java
@@ -41,6 +41,7 @@ public class RootControllerTest extends AbstractIntegrationTest {
 
     JsonContentAssert assertJson = assertThat(jsonTester.from(metaDataResponse.getBody()));
     assertJson.hasJsonPath("version");
+    assertJson.hasJsonPath("ilpOverHttpUrl");
   }
 
 }


### PR DESCRIPTION
Adds the URL of the connector that Hermes is configured to talk to to the Hermes metadata endpoint (`/`)