### PR TITLE
Re-fix bearer token stripping in grpc

### DIFF
--- a/src/main/java/org/interledger/spsp/server/grpc/auth/IlpGrpcMetadataReaderImpl.java
+++ b/src/main/java/org/interledger/spsp/server/grpc/auth/IlpGrpcMetadataReaderImpl.java
@@ -23,6 +23,7 @@ public class IlpGrpcMetadataReaderImpl implements IlpGrpcMetadataReader {
     // If the "Authorization" header exists, use it. Otherwise, see if we can find a jwt Cookie. If that doesn't exist,
     // return null so the AccountGrpcHandler can generate credentials
     return authorizationHeader
+      .map(token -> token.replace("Bearer ", ""))
       .orElseGet(() ->
         cookieHeaders
           .map(c -> {
@@ -33,7 +34,7 @@ public class IlpGrpcMetadataReaderImpl implements IlpGrpcMetadataReader {
               .filter($ -> $.getName().equals(JWT_COOKIE_NAME)) // JWT cookie exists?
               .findFirst()
               .map(HttpCookie::getValue) // if JWT cookie exists, return the value
-              .orElse(metadata.get(Metadata.Key.of(HttpHeaders.AUTHORIZATION, Metadata.ASCII_STRING_MARSHALLER))); // Otherwise get jwt from auth header
+              .orElse(null);
           })
           // Strip Bearer prefix
           .map(token -> token.replace("Bearer ", ""))

--- a/src/test/java/org/interledger/spsp/server/grpc/AccountGrpcHandlerTests.java
+++ b/src/test/java/org/interledger/spsp/server/grpc/AccountGrpcHandlerTests.java
@@ -169,7 +169,7 @@ public class AccountGrpcHandlerTests extends AbstractIntegrationTest  {
 
   @Test
   public void createAccountWithHeaderTokenButNoRequest() {
-    String authToken = "password";
+    String authToken = "Bearer password";
     CreateAccountRequest request = CreateAccountRequest.newBuilder()
       .build();
 
@@ -183,7 +183,7 @@ public class AccountGrpcHandlerTests extends AbstractIntegrationTest  {
     assertThat(reply.getAssetScale()).isEqualTo(9);
     assertThat(reply.getPaymentPointer()).isEqualTo(containers.paymentPointerBase() + "/" + reply.getAccountId());
     assertThat(reply.getCustomSettingsMap().get(IncomingLinkSettings.HTTP_INCOMING_AUTH_TYPE)).isEqualTo(IlpOverHttpLinkSettings.AuthType.SIMPLE.toString());
-    assertThat(reply.getCustomSettingsMap().get(IncomingLinkSettings.HTTP_INCOMING_SIMPLE_AUTH_TOKEN)).asString().isEqualTo(authToken);
+    assertThat(reply.getCustomSettingsMap().get(IncomingLinkSettings.HTTP_INCOMING_SIMPLE_AUTH_TOKEN)).asString().isEqualTo(authToken.replace("Bearer ", ""));
   }
 
   @Test
@@ -217,7 +217,7 @@ public class AccountGrpcHandlerTests extends AbstractIntegrationTest  {
 
   @Test
   public void testCreateAccountWithOnlyAssetDetails() {
-    String authToken = "password";
+    String authToken = "Bearer password";
     CreateAccountRequest request = CreateAccountRequest.newBuilder()
       .setAssetCode("XRP")
       .setAssetScale(9)
@@ -232,12 +232,12 @@ public class AccountGrpcHandlerTests extends AbstractIntegrationTest  {
     assertThat(reply.getAssetScale()).isEqualTo(9);
     assertThat(reply.getPaymentPointer()).isEqualTo(containers.paymentPointerBase() + "/" + reply.getAccountId());
     assertThat(reply.getCustomSettingsMap().get(IncomingLinkSettings.HTTP_INCOMING_AUTH_TYPE)).isEqualTo(IlpOverHttpLinkSettings.AuthType.SIMPLE.toString());
-    assertThat(reply.getCustomSettingsMap().get(IncomingLinkSettings.HTTP_INCOMING_SIMPLE_AUTH_TOKEN)).isEqualTo(authToken);
+    assertThat(reply.getCustomSettingsMap().get(IncomingLinkSettings.HTTP_INCOMING_SIMPLE_AUTH_TOKEN)).isEqualTo(authToken.replace("Bearer ", ""));
   }
 
   @Test
   public void createAccountWithSimpleAuthAndFullRequest() {
-    String authToken = "password";
+    String authToken = "Bearer password";
     CreateAccountRequest request = CreateAccountRequest.newBuilder()
       .setAccountId("foo")
       .setAssetCode("USD")
@@ -253,7 +253,7 @@ public class AccountGrpcHandlerTests extends AbstractIntegrationTest  {
     assertThat(reply.getAssetScale()).isEqualTo(4);
     assertThat(reply.getPaymentPointer()).isEqualTo(containers.paymentPointerBase() + "/" + reply.getAccountId());
     assertThat(reply.getCustomSettingsMap().get(IncomingLinkSettings.HTTP_INCOMING_AUTH_TYPE)).isEqualTo(IlpOverHttpLinkSettings.AuthType.SIMPLE.toString());
-    assertThat(reply.getCustomSettingsMap().get(IncomingLinkSettings.HTTP_INCOMING_SIMPLE_AUTH_TOKEN)).asString().isEqualTo(authToken);
+    assertThat(reply.getCustomSettingsMap().get(IncomingLinkSettings.HTTP_INCOMING_SIMPLE_AUTH_TOKEN)).asString().isEqualTo(authToken.replace("Bearer ", ""));
   }
 
   /**

--- a/src/test/java/org/interledger/spsp/server/grpc/AuthContextInterceptorTests.java
+++ b/src/test/java/org/interledger/spsp/server/grpc/AuthContextInterceptorTests.java
@@ -158,7 +158,7 @@ public class AuthContextInterceptorTests extends AbstractIntegrationTest {
    */
   @Test
   public void testCreateAccountWithCookieAuthAndAuthHeader() {
-    String authHeaderToken = "asdfdfkjsdhfksdjh";
+    String authHeaderToken = "Bearer asdfdfkjsdhfksdjh";
     CreateAccountRequest request = CreateAccountRequest.newBuilder()
       .build();
 
@@ -181,7 +181,8 @@ public class AuthContextInterceptorTests extends AbstractIntegrationTest {
       .withCallCredentials(IlpCallCredentials.build(authHeaderToken))
       .createAccount(request);
 
-    verify(accountService, times(1)).createAccount(eq(Optional.of(authHeaderToken)), any(Optional.class));
+    verify(accountService, times(1))
+      .createAccount(eq(Optional.of(authHeaderToken.replace("Bearer ", ""))), any(Optional.class));
     verify(accountService, times(0)).createAccount(eq(Optional.of(jwt)), any(Optional.class));
   }
 


### PR DESCRIPTION
In my last PR, I was only stripping "Bearer " from cookies, not auth headers :(