### PR TITLE
Use ObjectMapper for problems

### DIFF
--- a/src/main/java/org/interledger/spsp/server/config/jackson/JacksonConfig.java
+++ b/src/main/java/org/interledger/spsp/server/config/jackson/JacksonConfig.java
@@ -11,7 +11,7 @@ public class JacksonConfig {
   @Bean
   @Primary
   protected ObjectMapper objectMapper() {
-    return ObjectMapperFactory.create();
+    return ObjectMapperFactory.createObjectMapperForProblemsJson();
   }
 
 }


### PR DESCRIPTION
Fixes #46 

Had the same problem with the connector.  Problems don't get serialized correctly with the `ObjectMapper` that is created via `ObjectMapperFactory.create()`, so we have to use the `ObjectMapper` created by `ObjectMapperFactory.createObjectMapperForProblemsJson()`